### PR TITLE
Persist DB metadata when Rafiki is stopped & restarted

### DIFF
--- a/.env.sh
+++ b/.env.sh
@@ -8,9 +8,10 @@ export ADMIN_WEB_EXT_PORT=3001
 export ADVISOR_EXT_PORT=3002
 export POSTGRES_EXT_PORT=5433
 export REDIS_EXT_PORT=6380
-export DATA_WORKDIR_PATH=$PWD/data # Shares a data folder with containers
-export LOGS_WORKDIR_PATH=$PWD/logs # Shares a folder with containers that stores components' logs
+export DATA_WORKDIR_PATH=$PWD/data # Folder shared with containers that contains datasets
+export LOGS_WORKDIR_PATH=$PWD/logs # Folder shared with containers that stores components' logs
 export APP_MODE=DEV # DEV or PROD
+export POSTGRES_DUMP_FILE_PATH=$PWD/db_dump.sql # PostgreSQL database dump file
 
 # Internal credentials for Rafiki's components
 export POSTGRES_USER=rafiki

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ logs/*
 # IPython notebooks
 .ipynb_checkpoints/*
 *.ipynb
+
+# SQL dump files
+*.sql

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -1,12 +1,4 @@
-# Echo title with border
-title() 
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+source ./scripts/utils.sh
 
 # Build Rafiki's images
 

--- a/scripts/create_docker_swarm.sh
+++ b/scripts/create_docker_swarm.sh
@@ -1,3 +1,6 @@
+source ./scripts/utils.sh
+
+title "Creating Docker swarm for Rafiki..."
 docker swarm leave $1
 docker swarm init --advertise-addr $DOCKER_SWARM_ADVERTISE_ADDR \
     || >&2 echo "Failed to init Docker swarm - continuing..."

--- a/scripts/load_db.sh
+++ b/scripts/load_db.sh
@@ -1,10 +1,14 @@
 DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
 
+source ./scripts/utils.sh
+
+title "Maybe loading from database dump..." 
+
 # Check if dump file exists
 if [ -f $DUMP_FILE ]
 then 
     echo "Loading database dump at $DUMP_FILE..." 
-    cat $DUMP_FILE | docker exec -i $POSTGRES_HOST psql -U $POSTGRES_USER > /dev/null
+    cat $DUMP_FILE | docker exec -i $POSTGRES_HOST psql -U postgres --dbname $POSTGRES_DB > /dev/null
 else
     echo "No database dump file found." 
 fi

--- a/scripts/load_db.sh
+++ b/scripts/load_db.sh
@@ -1,0 +1,10 @@
+DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
+
+# Check if dump file exists
+if [ -f $DUMP_FILE ]
+then 
+    echo "Loading database dump at $DUMP_FILE..." 
+    cat $DUMP_FILE | docker exec -i $POSTGRES_HOST psql -U $POSTGRES_USER > /dev/null
+else
+    echo "No database dump file found." 
+fi

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -1,3 +1,5 @@
+source ./scripts/utils.sh
+
 pull_image()
 {
     if [[ ! -z $(docker images -q $1) ]]
@@ -8,6 +10,7 @@ pull_image()
     fi
 }
 
+title "Pulling images..."
 echo "Pulling images required by Rafiki from Docker Hub..."
 pull_image $IMAGE_POSTGRES
 pull_image $IMAGE_REDIS

--- a/scripts/save_db.sh
+++ b/scripts/save_db.sh
@@ -1,0 +1,4 @@
+DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
+
+echo "Dumping database to $DUMP_FILE..." 
+docker exec $POSTGRES_HOST pg_dumpall -U $POSTGRES_USER --clean > $DUMP_FILE

--- a/scripts/save_db.sh
+++ b/scripts/save_db.sh
@@ -1,4 +1,4 @@
 DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
 
 echo "Dumping database to $DUMP_FILE..." 
-docker exec $POSTGRES_HOST pg_dumpall -U $POSTGRES_USER --clean > $DUMP_FILE
+docker exec $POSTGRES_HOST pg_dump -U postgres --if-exists --clean $POSTGRES_DB > $DUMP_FILE

--- a/scripts/save_db.sh
+++ b/scripts/save_db.sh
@@ -7,9 +7,8 @@ then
     if [ $ok = "n" ] 
     then 
         echo "Not dumping database!" 
-        exit 1 
+    else
+        echo "Dumping database to $DUMP_FILE..." 
+        docker exec $POSTGRES_HOST pg_dump -U postgres --if-exists --clean $POSTGRES_DB > $DUMP_FILE
     fi
 fi
-
-echo "Dumping database to $DUMP_FILE..." 
-docker exec $POSTGRES_HOST pg_dump -U postgres --if-exists --clean $POSTGRES_DB > $DUMP_FILE

--- a/scripts/save_db.sh
+++ b/scripts/save_db.sh
@@ -1,4 +1,15 @@
 DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
 
+# Check if dump file exists
+if [ -f $DUMP_FILE ]
+then 
+    read -p "Database dump file exists at $DUMP_FILE. Override it? (y/n) " ok
+    if [ $ok = "n" ] 
+    then 
+        echo "Not dumping database!" 
+        exit 1 
+    fi
+fi
+
 echo "Dumping database to $DUMP_FILE..." 
 docker exec $POSTGRES_HOST pg_dump -U postgres --if-exists --clean $POSTGRES_DB > $DUMP_FILE

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,59 +1,21 @@
-LOG_FILEPATH=$PWD/logs/start.log
-FILE_DIR=$(dirname "$0")
-
 source ./scripts/utils.sh
 
 # Read from shell configuration file
 source ./.env.sh
 
-ensure_stable()
-{
-    echo "Waiting for 10s for $1 to stablize..."
-    sleep 10
-    if ps -p $! > /dev/null
-    then
-        echo "$1 is running"
-    else
-        echo "Error running $1"
-        echo "Check the logs at $LOG_FILEPATH"
-        exit 1
-    fi
-}
-
 # Create Docker swarm for Rafiki
-
-title "Creating Docker swarm for Rafiki..."
-bash $FILE_DIR/create_docker_swarm.sh
+bash ./scripts/create_docker_swarm.sh
 
 # Pull images from Docker Hub
-
-title "Pulling images for Rafiki from Docker Hub..."
-bash $FILE_DIR/pull_images.sh
+bash ./scripts/pull_images.sh || exit 1
 
 # Start whole Rafiki stack
-
-title "Starting Rafiki's DB..."
-(bash $FILE_DIR/start_db.sh &> $LOG_FILEPATH) &
-ensure_stable "Rafiki's DB"
-
-title "Maybe loading from database dump..." 
-bash $FILE_DIR/load_db.sh
-
-title "Starting Rafiki's Cache..."
-(bash $FILE_DIR/start_cache.sh &> $LOG_FILEPATH) &
-ensure_stable "Rafiki's Cache"
-
-title "Starting Rafiki's Admin..."
-(bash $FILE_DIR/start_admin.sh &> $LOG_FILEPATH) &
-ensure_stable "Rafiki's Admin"
-
-title "Starting Rafiki's Advisor..."
-(bash $FILE_DIR/start_advisor.sh &> $LOG_FILEPATH) &
-ensure_stable "Rafiki's Advisor"
-
-title "Starting Rafiki's Admin Web..."
-(bash $FILE_DIR/start_admin_web.sh &> $LOG_FILEPATH) &
-ensure_stable "Rafiki's Admin Web"
+bash ./scripts/start_db.sh || exit 1
+bash ./scripts/load_db.sh || exit 1
+bash ./scripts/start_cache.sh || exit 1
+bash ./scripts/start_admin.sh || exit 1
+bash ./scripts/start_advisor.sh || exit 1
+bash ./scripts/start_admin_web.sh || exit 1
 
 title "Installing any dependencies..."
 pip install -r ./rafiki/client/requirements.txt

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,18 +1,10 @@
-# Read from shell configuration file
-source ./.env.sh
-
 LOG_FILEPATH=$PWD/logs/start.log
 FILE_DIR=$(dirname "$0")
 
-# Echo title with border
-title() 
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+source ./scripts/utils.sh
+
+# Read from shell configuration file
+source ./.env.sh
 
 ensure_stable()
 {
@@ -43,6 +35,9 @@ bash $FILE_DIR/pull_images.sh
 title "Starting Rafiki's DB..."
 (bash $FILE_DIR/start_db.sh &> $LOG_FILEPATH) &
 ensure_stable "Rafiki's DB"
+
+title "Maybe loading from database dump..." 
+bash $FILE_DIR/load_db.sh
 
 title "Starting Rafiki's Cache..."
 (bash $FILE_DIR/start_cache.sh &> $LOG_FILEPATH) &

--- a/scripts/start_admin.sh
+++ b/scripts/start_admin.sh
@@ -40,4 +40,4 @@ title "Starting Rafiki's Admin..."
   $RAFIKI_IMAGE_ADMIN:$RAFIKI_VERSION \
   &> $LOG_FILE_PATH) &
 
-ensure_stable "Rafiki's Admin" $LOG_FILE_PATH
+ensure_stable "Rafiki's Admin" $LOG_FILE_PATH 10

--- a/scripts/start_admin.sh
+++ b/scripts/start_admin.sh
@@ -1,3 +1,5 @@
+LOG_FILE_PATH=$PWD/logs/start_admin.log
+
 # Mount whole project folder with code for dev for shorter iterations
 if [ $APP_MODE = "DEV" ]; then
   VOLUME_MOUNTS="-v $PWD:$DOCKER_WORKDIR_PATH"
@@ -5,7 +7,11 @@ else
   VOLUME_MOUNTS="-v $LOGS_WORKDIR_PATH:$LOGS_DOCKER_WORKDIR_PATH -v $DATA_WORKDIR_PATH:$DATA_DOCKER_WORKDIR_PATH"
 fi
 
-docker run --rm --name $ADMIN_HOST \
+source ./scripts/utils.sh
+
+title "Starting Rafiki's Admin..."
+
+(docker run --rm --name $ADMIN_HOST \
   --network $DOCKER_NETWORK \
   -e POSTGRES_HOST=$POSTGRES_HOST \
   -e POSTGRES_PORT=$POSTGRES_PORT \
@@ -31,4 +37,7 @@ docker run --rm --name $ADMIN_HOST \
   -v /var/run/docker.sock:/var/run/docker.sock \
   $VOLUME_MOUNTS \
   -p $ADMIN_EXT_PORT:$ADMIN_PORT \
-  $RAFIKI_IMAGE_ADMIN:$RAFIKI_VERSION
+  $RAFIKI_IMAGE_ADMIN:$RAFIKI_VERSION \
+  &> $LOG_FILE_PATH) &
+
+ensure_stable "Rafiki's Admin" $LOG_FILE_PATH

--- a/scripts/start_admin_web.sh
+++ b/scripts/start_admin_web.sh
@@ -11,4 +11,4 @@ title "Starting Rafiki's Web Admin..."
   $RAFIKI_IMAGE_ADMIN_WEB:$RAFIKI_VERSION \
   &> $LOG_FILE_PATH) &
 
-ensure_stable "Rafiki's Web Admin" $LOG_FILE_PATH
+ensure_stable "Rafiki's Web Admin" $LOG_FILE_PATH 10

--- a/scripts/start_admin_web.sh
+++ b/scripts/start_admin_web.sh
@@ -1,6 +1,14 @@
-docker run --rm --name $ADMIN_WEB_HOST \
+LOG_FILE_PATH=$PWD/logs/start_admin_web.log
+
+source ./scripts/utils.sh
+
+title "Starting Rafiki's Web Admin..."
+(docker run --rm --name $ADMIN_WEB_HOST \
   --network $DOCKER_NETWORK \
   -e RAFIKI_ADDR=$RAFIKI_ADDR \
   -e ADMIN_EXT_PORT=$ADMIN_EXT_PORT \
   -p $ADMIN_WEB_EXT_PORT:3001 \
-  $RAFIKI_IMAGE_ADMIN_WEB:$RAFIKI_VERSION
+  $RAFIKI_IMAGE_ADMIN_WEB:$RAFIKI_VERSION \
+  &> $LOG_FILE_PATH) &
+
+ensure_stable "Rafiki's Web Admin" $LOG_FILE_PATH

--- a/scripts/start_advisor.sh
+++ b/scripts/start_advisor.sh
@@ -1,3 +1,5 @@
+LOG_FILE_PATH=$PWD/logs/start_advisor.log
+
 # Mount whole project folder with code for dev for shorter iterations
 if [ $APP_MODE = "DEV" ]; then
   VOLUME_MOUNTS="-v $PWD:$DOCKER_WORKDIR_PATH"
@@ -5,7 +7,10 @@ else
   VOLUME_MOUNTS="-v $LOGS_WORKDIR_PATH:$LOGS_DOCKER_WORKDIR_PATH -v $DATA_WORKDIR_PATH:$DATA_DOCKER_WORKDIR_PATH"
 fi
 
-docker run --rm --name $ADVISOR_HOST \
+source ./scripts/utils.sh
+
+title "Starting Rafiki's Advisor..."
+(docker run --rm --name $ADVISOR_HOST \
   --network $DOCKER_NETWORK \
   -e LOGS_WORKDIR_PATH=$LOGS_WORKDIR_PATH \
   -e DATA_WORKDIR_PATH=$DATA_WORKDIR_PATH \
@@ -13,4 +18,7 @@ docker run --rm --name $ADVISOR_HOST \
   -e DATA_DOCKER_WORKDIR_PATH=$DATA_DOCKER_WORKDIR_PATH \
   $VOLUME_MOUNTS \
   -p $ADVISOR_EXT_PORT:$ADVISOR_PORT \
-  $RAFIKI_IMAGE_ADVISOR:$RAFIKI_VERSION
+  $RAFIKI_IMAGE_ADVISOR:$RAFIKI_VERSION \
+  &> $LOG_FILE_PATH) &
+
+ensure_stable "Rafiki's Advisor" $LOG_FILE_PATH

--- a/scripts/start_advisor.sh
+++ b/scripts/start_advisor.sh
@@ -21,4 +21,4 @@ title "Starting Rafiki's Advisor..."
   $RAFIKI_IMAGE_ADVISOR:$RAFIKI_VERSION \
   &> $LOG_FILE_PATH) &
 
-ensure_stable "Rafiki's Advisor" $LOG_FILE_PATH
+ensure_stable "Rafiki's Advisor" $LOG_FILE_PATH 10

--- a/scripts/start_cache.sh
+++ b/scripts/start_cache.sh
@@ -9,4 +9,4 @@ title "Starting Rafiki's Cache..."
   $IMAGE_REDIS \
   &> $LOG_FILE_PATH) &
 
-ensure_stable "Rafiki's Cache" $LOG_FILE_PATH
+ensure_stable "Rafiki's Cache" $LOG_FILE_PATH 10

--- a/scripts/start_cache.sh
+++ b/scripts/start_cache.sh
@@ -1,4 +1,12 @@
-docker run --rm --name $REDIS_HOST \
+LOG_FILE_PATH=$PWD/logs/start_cache.log
+
+source ./scripts/utils.sh
+
+title "Starting Rafiki's Cache..."
+(docker run --rm --name $REDIS_HOST \
   --network $DOCKER_NETWORK \
   -p $REDIS_EXT_PORT:$REDIS_PORT \
-  $IMAGE_REDIS
+  $IMAGE_REDIS \
+  &> $LOG_FILE_PATH) &
+
+ensure_stable "Rafiki's Cache" $LOG_FILE_PATH

--- a/scripts/start_db.sh
+++ b/scripts/start_db.sh
@@ -12,7 +12,7 @@ title "Starting Rafiki's DB..."
   $IMAGE_POSTGRES \
   &> $LOG_FILE_PATH) &
 
-ensure_stable "Rafiki's DB" $LOG_FILE_PATH
+ensure_stable "Rafiki's DB" $LOG_FILE_PATH 20
 
 echo "Creating Rafiki's PostgreSQL database & user..."
 docker exec $POSTGRES_HOST psql -U postgres -c "CREATE DATABASE $POSTGRES_DB"

--- a/scripts/start_db.sh
+++ b/scripts/start_db.sh
@@ -1,9 +1,19 @@
-docker run --rm --name $POSTGRES_HOST \
+LOG_FILE_PATH=$PWD/logs/start_db.log
+
+source ./scripts/utils.sh
+
+title "Starting Rafiki's DB..."
+(docker run --rm --name $POSTGRES_HOST \
   --network $DOCKER_NETWORK \
   -e POSTGRES_HOST=$POSTGRES_HOST \
   -e POSTGRES_PORT=$POSTGRES_PORT \
-  -e POSTGRES_USER=$POSTGRES_USER \
-  -e POSTGRES_DB=$POSTGRES_DB \
   -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
   -p $POSTGRES_EXT_PORT:$POSTGRES_PORT \
-  $IMAGE_POSTGRES
+  $IMAGE_POSTGRES \
+  &> $LOG_FILE_PATH) &
+
+ensure_stable "Rafiki's DB" $LOG_FILE_PATH
+
+echo "Creating Rafiki's PostgreSQL database & user..."
+docker exec $POSTGRES_HOST psql -U postgres -c "CREATE DATABASE $POSTGRES_DB"
+docker exec $POSTGRES_HOST psql -U postgres -c "CREATE USER $POSTGRES_USER WITH PASSWORD '$POSTGRES_PASSWORD'"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -8,7 +8,7 @@ title "Stopping any existing jobs..."
 python3.6 ./scripts/stop_all_jobs.py
 
 title "Dumping database..." 
-bash ./scripts/save_db.sh
+bash ./scripts/save_db.sh || exit 1
 
 title "Stopping Rafiki's DB..."
 docker rm -f $POSTGRES_HOST || echo "Failed to stop Rafiki's DB"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,16 +1,14 @@
 LOG_FILEPATH=$PWD/logs/stop.log
-FILE_DIR=$(dirname "$0")
-
 source ./scripts/utils.sh
 
 # Read from shell configuration file
 source ./.env.sh
 
 title "Stopping any existing jobs..."
-python3.6 scripts/stop_all_jobs.py
+python3.6 ./scripts/stop_all_jobs.py
 
 title "Dumping database..." 
-bash $FILE_DIR/save_db.sh
+bash ./scripts/save_db.sh
 
 title "Stopping Rafiki's DB..."
 docker rm -f $POSTGRES_HOST || echo "Failed to stop Rafiki's DB"
@@ -24,8 +22,8 @@ docker rm -f $ADMIN_HOST || echo "Failed to stop Rafiki's Admin"
 title "Stopping Rafiki's Advisor..."
 docker rm -f $ADVISOR_HOST || echo "Failed to stop Rafiki's Advisor"
 
-title "Stopping Rafiki's Admin Web..."
-docker rm -f $ADMIN_WEB_HOST || echo "Failed to stop Rafiki's Admin Web"
+title "Stopping Rafiki's Web Admin..."
+docker rm -f $ADMIN_WEB_HOST || echo "Failed to stop Rafiki's Web Admin"
 
 echo "You'll need to destroy your machine's Docker swarm manually"
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,19 +1,16 @@
-source ./.env.sh
-
 LOG_FILEPATH=$PWD/logs/stop.log
+FILE_DIR=$(dirname "$0")
 
-# Echo title with border
-title() 
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+source ./scripts/utils.sh
+
+# Read from shell configuration file
+source ./.env.sh
 
 title "Stopping any existing jobs..."
 python3.6 scripts/stop_all_jobs.py
+
+title "Dumping database..." 
+bash $FILE_DIR/save_db.sh
 
 title "Stopping Rafiki's DB..."
 docker rm -f $POSTGRES_HOST || echo "Failed to stop Rafiki's DB"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -8,7 +8,17 @@ title "Stopping any existing jobs..."
 python3.6 ./scripts/stop_all_jobs.py
 
 title "Dumping database..." 
-bash ./scripts/save_db.sh || exit 1
+bash ./scripts/save_db.sh
+
+# If database dump previously failed, prompt whether to continue script
+if [ $? -ne 0 ]
+then
+    read -p "Failed to dump database. Continue? (y/n) " ok
+    if [ $ok = "n" ]
+    then
+        exit 1
+    fi
+fi
 
 title "Stopping Rafiki's DB..."
 docker rm -f $POSTGRES_HOST || echo "Failed to stop Rafiki's DB"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -7,3 +7,21 @@ title()
     echo "$title"
     echo "$edge"
 }
+
+# Ensure docker container is stable
+ensure_stable()
+{
+    echo "Waiting for 10s for $1 to stablize..."
+    sleep 10
+    if ps -p $! > /dev/null
+    then
+        echo "$1 is running"
+    else
+        echo "Error running $1"
+        if ! [ -z "$2" ]
+        then
+            echo "Check the logs at $2"
+        fi
+        exit 1
+    fi
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -20,6 +20,7 @@ ensure_stable()
         echo "$1 is running"
     else
         echo "Error running $1"
+        echo "Maybe $1 hasn't previously been stopped - try running `scripts/stop.sh`?"
         if ! [ -z "$LOG_FILE_PATH" ]
         then
             echo "Check the logs at $LOG_FILE_PATH"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -11,16 +11,18 @@ title()
 # Ensure docker container is stable
 ensure_stable()
 {
-    echo "Waiting for 10s for $1 to stablize..."
-    sleep 10
+    LOG_FILE_PATH=$2
+    SLEEP_TIME=$3
+    echo "Waiting for ${SLEEP_TIME}s for $1 to stabilize..."
+    sleep $SLEEP_TIME
     if ps -p $! > /dev/null
     then
         echo "$1 is running"
     else
         echo "Error running $1"
-        if ! [ -z "$2" ]
+        if ! [ -z "$LOG_FILE_PATH" ]
         then
-            echo "Check the logs at $2"
+            echo "Check the logs at $LOG_FILE_PATH"
         fi
         exit 1
     fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,9 @@
+# Echo title with border
+title() 
+{
+    title="| $1 |"
+    edge=$(echo "$title" | sed 's/./-/g')
+    echo "$edge"
+    echo "$title"
+    echo "$edge"
+}


### PR DESCRIPTION
Fixes #19 

GIVEN Rafiki admin has started Rafiki, model developers have created a few models, and application developers have run a few train/inference jobs
WHEN the admin restarts Rafiki with `scripts/stop.sh` and `scripts/start.sh`
THEN Rafiki's user, job & model data should persist

@cadmusthefounder to test & verify that this works