### PR TITLE
Allow use of GPU for inference jobs

### DIFF
--- a/docs/src/python/rafiki.constants.rst
+++ b/docs/src/python/rafiki.constants.rst
@@ -9,6 +9,8 @@ rafiki.constants
 
 .. autoclass:: rafiki.constants.BudgetOption
 
+.. autoclass:: rafiki.constants.InferenceBudgetOption
+
 .. autoclass:: rafiki.constants.UserType
 
 .. autoclass:: rafiki.constants.ModelDependency

--- a/examples/scripts/quickstart.py
+++ b/examples/scripts/quickstart.py
@@ -25,7 +25,7 @@ import os
 
 from rafiki.client import Client
 from rafiki.config import SUPERADMIN_EMAIL
-from rafiki.constants import BudgetOption, InferenceJobStatus, ModelDependency
+from rafiki.constants import BudgetOption, InferenceBudgetOption, InferenceJobStatus, ModelDependency
 from rafiki.model import utils
 
 from examples.scripts.utils import gen_id, wait_until_train_job_has_stopped
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     parser.add_argument('--web_admin_port', type=int, default=os.environ.get('WEB_ADMIN_EXT_PORT', 3001), help='Port for Rafiki Web Admin on host')
     parser.add_argument('--email', type=str, default=SUPERADMIN_EMAIL, help='Email of user')
     parser.add_argument('--password', type=str, default=os.environ.get('SUPERADMIN_PASSWORD'), help='Password of user')
-    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use')
+    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use for training')
     parser.add_argument('--hours', type=float, default=0.1, help='How long the train job should run for (in hours)') # 6min
     parser.add_argument('--query_path', type=str, 
                         default='examples/data/image_classification/fashion_mnist_test_1.png,examples/data/image_classification/fashion_mnist_test_2.png', 

--- a/examples/scripts/run_pos_tagging.py
+++ b/examples/scripts/run_pos_tagging.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--email', type=str, default=SUPERADMIN_EMAIL, help='Email of user')
     parser.add_argument('--password', type=str, default=os.environ.get('SUPERADMIN_PASSWORD'), help='Password of user')
-    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use')
+    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use for training')
     parser.add_argument('--hours', type=float, default=0.1, help='How long the train job should run for (in hours)') 
     (args, _) = parser.parse_known_args()
     out_train_dataset_path = 'data/ptb_train.zip'

--- a/examples/scripts/run_tabular_regression.py
+++ b/examples/scripts/run_tabular_regression.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--email', type=str, default=SUPERADMIN_EMAIL, help='Email of user')
     parser.add_argument('--password', type=str, default=os.environ.get('SUPERADMIN_PASSWORD'), help='Password of user')
-    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use')
+    parser.add_argument('--gpus', type=int, default=0, help='How many GPUs to use for training')
     parser.add_argument('--hours', type=float, default=0.1, help='How long the train job should run for (in hours)') 
     parser.add_argument('--csv', type=str, default='https://course1.winona.edu/bdeppa/Stat%20425/Data/bodyfat.csv', help='Path to a standard CSV file to perform regression on')
     parser.add_argument('--features', type=str, default=None, help='List of feature columns\' names as comma separated values')

--- a/rafiki/admin/admin.py
+++ b/rafiki/admin/admin.py
@@ -437,7 +437,7 @@ class Admin(object):
     # Inference Job
     ####################################
 
-    def create_inference_job(self, user_id, app, app_version):
+    def create_inference_job(self, user_id, app, app_version, budget):
         train_job = self._meta_store.get_train_job_by_app_version(user_id, app, app_version=app_version)
         if train_job is None:
             raise InvalidTrainJobError('Have you started a train job for this app?')
@@ -455,10 +455,11 @@ class Admin(object):
         if len(best_trials) == 0:
             raise InvalidTrainJobError('Train job has no trials with saved models!')
 
-        # Create inference & sub inference jobs in DB
+        # Create inference job in DB
         inference_job = self._meta_store.create_inference_job(
             user_id=user_id,
-            train_job_id=train_job.id
+            train_job_id=train_job.id,
+            budget=budget
         )
         self._meta_store.commit()
 

--- a/rafiki/constants.py
+++ b/rafiki/constants.py
@@ -25,6 +25,12 @@ class BudgetOption():
     MODEL_TRIAL_COUNT = 'MODEL_TRIAL_COUNT'
 
 Budget = Dict[BudgetOption, Any]
+
+class InferenceBudgetOption():
+    GPU_COUNT = 'GPU_COUNT'
+
+InferenceBudget = Dict[InferenceBudgetOption, Any]
+
 ModelDependencies = Dict[str, str]
 
 class ModelAccessRight():

--- a/rafiki/meta_store/meta_store.py
+++ b/rafiki/meta_store/meta_store.py
@@ -264,10 +264,11 @@ class MetaStore(object):
     # Inference Jobs
     ####################################
     
-    def create_inference_job(self, user_id, train_job_id):
+    def create_inference_job(self, user_id, train_job_id, budget):
         inference_job = InferenceJob(
             user_id=user_id,
-            train_job_id=train_job_id
+            train_job_id=train_job_id,
+            budget=budget
         )
         self._session.add(inference_job)
         return inference_job

--- a/rafiki/meta_store/schema.py
+++ b/rafiki/meta_store/schema.py
@@ -40,6 +40,7 @@ class InferenceJob(Base):
     id = Column(String, primary_key=True, default=generate_uuid)
     datetime_started = Column(DateTime, nullable=False, default=generate_datetime)
     train_job_id = Column(String, ForeignKey('train_job.id'))
+    budget = Column(JSON, default={})
     status = Column(String, nullable=False, default=InferenceJobStatus.STARTED)
     user_id = Column(String, ForeignKey('user.id'), nullable=False)
     predictor_service_id = Column(String, ForeignKey('service.id'))


### PR DESCRIPTION
Fixes #141 

Inference job workers (which make predictions with trained models) can now be configured to use GPUs by passing an optional `budget` argument to the `client.create_inference_job` method. Refer to the documentation changes in this PR.