### PR TITLE
Prepare for `v0.2.0` release

### DIFF
--- a/.env.sh
+++ b/.env.sh
@@ -25,7 +25,7 @@ export APP_SECRET=rafiki
 # Core external configuration for Rafiki
 export DOCKER_NETWORK=rafiki
 export DOCKER_SWARM_ADVERTISE_ADDR=127.0.0.1
-export RAFIKI_VERSION=0.3.0
+export RAFIKI_VERSION=0.2.0
 export RAFIKI_ADDR=127.0.0.1
 export ADMIN_EXT_PORT=3000
 export WEB_ADMIN_EXT_PORT=3001

--- a/docs/src/dev/development.rst
+++ b/docs/src/dev/development.rst
@@ -3,13 +3,15 @@
 Development
 ====================================================================
 
-Before running any individual scripts, make sure to run the shell configuration script:
+**Before running any individual scripts, make sure to run the shell configuration script**:
 
     .. code-block:: shell
 
         source .env.sh
 
 Refer to :ref:`architecture` and :ref:`folder-structure` for a developer's overview of Rafiki.
+
+.. _`testing-latest-code`:
 
 Testing Latest Code Changes
 --------------------------------------------------------------------
@@ -27,6 +29,51 @@ To test the lastet code changes e.g. in the ``dev`` branch, you'll need to do th
     .. code-block:: shell
 
         bash scripts/clean.sh
+
+
+Making a Release to ``master``
+--------------------------------------------------------------------
+
+In general, before making a release to ``master`` from ``dev``, ensure that the code at ``dev`` is stable & well-tested:
+    
+    1. Consider running all of Rafiki's tests (see :ref:`testing-rafiki`). Remember to re-build the Docker images to ensure the latest code changes are reflected (see :ref:`testing-latest-code`)
+
+    2. Consider running all of Rafiki's example models in `./examples/models/ <https://github.com/nginyc/rafiki/tree/master/examples/models/>`_
+
+    3. Consider running all of Rafiki's example usage scripts in `./examples/scripts/ <https://github.com/nginyc/rafiki/tree/master/examples/scripts/>`_
+
+    4. Consider running all of Rafiki's example dataset-preparation scripts in `./examples/datasets/ <https://github.com/nginyc/rafiki/tree/master/examples/datasets/>`_
+
+    5. Consider visiting Rafiki Web Admin and manually testing it
+
+    6. Consider building Rafiki's documentation site and checking if the documentation matches the codebase (see :ref:`building-docs`)
+
+After merging ``dev`` into ``master``, do the following:
+
+    1. Build & push Rafiki's new Docker images to `Rafiki’s own Docker Hub account <https://hub.docker.com/u/rafikiai>`_:
+
+        .. code-block:: shell
+
+            bash scripts/build_images.sh
+            bash scripts/push_images.sh
+
+        Get Docker Hub credentials from @nginyc.
+
+    2. Build & deploy Rafiki's new documentation to ``Rafiki's microsite powered by Github Pages``. Checkout Rafiki's ``gh-pages`` branch, then run the following:
+
+        .. code-block:: shell
+
+            bash scripts/build_docs.sh latest
+
+        Finally, commit all resultant generated documentation changes and push them to `gh-pages` branch. The latest documentation should be reflected at https://nginyc.github.io/rafiki/docs/latest/.
+        
+        Refer to `documentation on Github Pages <https://guides.github.com/features/pages/>` to understand more on how this works. 
+
+
+    3. `Draft a new release on Github <https://github.com/nginyc/rafiki/releases/new>`_. Make sure to include the list of changes relative to the previous release.
+
+
+Subsequently, you'll need to increase ``RAFIKI_VERSION`` in ``.env.sh`` to reflect a new release.
 
 
 Managing Rafiki's DB
@@ -76,6 +123,8 @@ To push the Rafiki's latest images to Docker Hub (e.g. to reflect the latest cod
 
         bash scripts/push_images.sh
 
+.. _`building-docs`:
+
 Building Rafiki's Documentation
 --------------------------------------------------------------------
 
@@ -87,12 +136,16 @@ Build & view Rafiki's Sphinx documentation on your machine with the following co
         bash scripts/build_docs.sh latest
         open docs/index.html
 
-Testing
+.. _`testing-rafiki`:
+
+Running Rafiki's Tests
 --------------------------------------------------------------------
 
 Rafiki uses `pytest <https://docs.pytest.org>`_.  
 
-Running all tests:
+First, start Rafiki.
+
+Then, run all integration tests with:
 
     ::
 

--- a/rafiki/model/dataset.py
+++ b/rafiki/model/dataset.py
@@ -29,7 +29,7 @@ import io
 import abc
 import csv
 import pandas
-import json
+import tempfile
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -39,6 +39,4 @@ docker build -t $RAFIKI_IMAGE_PREDICTOR:$RAFIKI_VERSION -f ./dockerfiles/predict
 title "Building Rafiki Web Admin's image..."
 docker build -t $RAFIKI_IMAGE_WEB_ADMIN:$RAFIKI_VERSION -f ./dockerfiles/web_admin.Dockerfile \
     --build-arg DOCKER_WORKDIR_PATH=$DOCKER_WORKDIR_PATH $PWD || exit 1 
-title "Building example model TfDeepSpeech's image..."
-bash examples/models/speech_recognition/tfdeepspeech/build_image.sh || exit 1
 echo "Finished building all Rafiki's images successfully!"


### PR DESCRIPTION
- Fix bug where all train jobs error during trials due to `dataset.py`
- Restore `RAFIKI_VERSION` as `0.2.0` (previous release was `0.1.0`)
- Add docs for making a release to `master`. Built docs here: https://nginyc.github.io/rafiki/docs/0.2.0/src/dev/development.html#making-a-release-to-master