### PR TITLE
Rafiki run in kubernetes and PostgreSQL high availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,31 @@ Prerequisites: MacOS or Linux environment
 
 4. Setup Rafiki's complete stack with the setup script:
 
+   if use docker swarm mode, use this script: 
+
     ```sh
     bash scripts/start.sh
     ```
-
+    
+   if use kubernetes mode, use this script:
+   
+    ```sh
+    bash scripts/kubernetes/start.sh
+    ```
+    
 To completely destroy Rafiki's stack:
 
-```sh
-bash scripts/stop.sh
-```
+   if use docker swarm mode, use this script:
+
+    ```sh
+    bash scripts/stop.sh
+    ```
+    
+   if user kubernetes mode, use this script:
+   
+    ```sh
+    bash scripts/kubernetes/stop.sh
+    ```
 
 More instructions are available in [Rafiki's Developer Guide](https://nginyc.github.io/rafiki/docs/latest/src/dev).
 

--- a/rafiki/admin/requirements.txt
+++ b/rafiki/admin/requirements.txt
@@ -1,3 +1,4 @@
 bcrypt>=3.1.4
 Flask==1.0.2
 Flask-Cors==3.0.6
+kubernetes==10.0.0

--- a/rafiki/admin/services_manager.py
+++ b/rafiki/admin/services_manager.py
@@ -455,7 +455,11 @@ class ServicesManager(object):
             publish_port = (ext_port, container_port)
 
         try:
-            container_service_name = 'rafiki_service_{}'.format(service.id)
+            container_service_name = ''
+            if os.getenv('CONTAINER_MODE', 'SWARM') == 'SWARM':
+                container_service_name = 'rafiki_service_{}'.format(service.id)
+            else:
+                container_service_name = 'rafiki-service-{}'.format(service.id)
             container_service = self._container_manager.create_service(
                 service_name=container_service_name,
                 docker_image=docker_image, 

--- a/rafiki/container/kubernetes_operation.py
+++ b/rafiki/container/kubernetes_operation.py
@@ -1,0 +1,165 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+import time
+import kubernetes
+import kubernetes.client
+from kubernetes import config
+import logging
+import traceback
+from collections import namedtuple
+from functools import wraps
+
+from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
+
+RETRY_WAIT_SECS = 1
+RETRY_TIMES = 5
+
+logger = logging.getLogger(__name__)
+
+class KubernetesContainerManager(ContainerManager):
+    def __init__(self, **kwargs):
+        aToken = None
+        with open('/var/run/secrets/kubernetes.io/serviceaccount/token', 'r') as fToken:
+            aToken = fToken.read()
+
+        # Create a configuration object
+        aConfiguration = kubernetes.client.Configuration()
+
+        # Specify the endpoint of your Kube cluster
+        aConfiguration.host = "https://{}:{}".format(os.getenv('KUBERNETES_SERVICE_HOST'), os.getenv('KUBERNETES_SERVICE_PORT'))
+
+        # Security part.
+        # In this simple example we are not going to verify the SSL certificate of
+        # the remote cluster (for simplicity reason)
+        aConfiguration.verify_ssl = False
+        # Nevertheless if you want to do it you can with these 2 parameters
+        # configuration.verify_ssl=True
+        # ssl_ca_cert is the filepath to the file that contains the certificate.
+        # configuration.ssl_ca_cert="certificate"
+
+        aConfiguration.api_key = {"authorization": "Bearer " + aToken}
+
+        # Create a ApiClient with our config
+        aApiClient = kubernetes.client.ApiClient(aConfiguration)
+
+        self._client_deployment = kubernetes.client.AppsV1Api(aApiClient)
+        self._client_service = kubernetes.client.CoreV1Api(aApiClient)
+
+    def destroy_service(self, service: ContainerService):
+        self._client_deployment.delete_namespaced_deployment(service.id, namespace='default')
+        self._client_service.delete_namespaced_service(service.id, namespace='default')
+
+    def create_service(self, service_name, docker_image, replicas, 
+                       args, environment_vars, mounts={}, publish_port=None,
+                       gpus=0) -> ContainerService:
+        hostname = service_name
+        if publish_port is not None:
+            service_config = self._create_service_config(service_name, docker_image, replicas, 
+                            args, environment_vars, mounts, publish_port,
+                            gpus)
+            service_obj = _retry(self._client_service.create_namespaced_service)(namespace='default', body=service_config)
+        deployment_config = self._create_deployment_config(service_name, docker_image, replicas, 
+                        args, environment_vars, mounts, publish_port,
+                        gpus)
+        deployment_obj = _retry(self._client_deployment.create_namespaced_deployment)(namespace='default', body=deployment_config)
+
+        info = {
+            'node_id': 'default',
+            'gpu_nos': gpus,
+            'service_name': service_name,
+            'replicas': replicas
+        }
+
+        service = ContainerService(service_name, hostname, publish_port[0] if publish_port is not None else None, info)
+        return service
+ 
+    def _create_deployment_config(self, service_name, docker_image, replicas, 
+                        args, environment_vars, mounts={}, publish_port=None,
+                        gpus=0):
+        content = {}
+        content.setdefault('apiVersion', 'apps/v1')      
+        content.setdefault('kind', 'Deployment')
+        metadata = content.setdefault('metadata', {})
+        metadata.setdefault('name', service_name)
+        labels = metadata.setdefault('labels', {})
+        labels.setdefault('name', service_name)
+        spec = content.setdefault('spec', {})
+        spec.setdefault('replicas', replicas)
+        spec.setdefault('selector', {'matchLabels': {'name': service_name}})
+        template = spec.setdefault('template', {})
+        template.setdefault('metadata', {'labels': {'name': service_name}})
+        container = {}
+        container.setdefault('name', service_name)
+        container.setdefault('image', docker_image)
+        volumeMounts = container.setdefault('volumeMounts', [])
+        volumes = []
+        mounts_count = 0
+        for (k, v) in mounts.items():
+            volumeMounts.append({'name': 'v' + str(mounts_count), 'mountPath': v})
+            volumes.append({'name': 'v' + str(mounts_count), 'hostPath': {'path': k}})
+            mounts_count += 1
+        template.setdefault('spec', {'containers': [container], 'volumes': volumes})
+        env = [{'name': k, 'value': v} for (k, v) in environment_vars.items()]
+        container.setdefault('env', env)
+        if gpus > 0:
+            container.setdefault('resources', {'limits': {'nvidia.com/gpu': gpus}})
+        return content
+    
+    def _create_service_config(self, service_name, docker_image, replicas, 
+                        args, environment_vars, mounts={}, publish_port=None,
+                        gpus=0):
+        #admin service
+        content = {}
+        content.setdefault('apiVersion', 'v1')
+        content.setdefault('kind', 'Service')
+        metadata = content.setdefault('metadata', {})
+        metadata.setdefault('name', service_name)
+        labels = metadata.setdefault('labels', {})
+        labels.setdefault('name', service_name)
+        spec = content.setdefault('spec', {})
+        if publish_port is not None:
+            spec.setdefault('type', 'NodePort')
+            ports = spec.setdefault('ports', [])
+            ports.append({'port': int(publish_port[1]), 'targetPort': int(publish_port[1]), 'nodePort': int(publish_port[0])})
+        spec.setdefault('selector', {'name': service_name})
+        return content
+
+# Decorator that retries a method call a number of times
+def _retry(func):
+    wait_secs = RETRY_WAIT_SECS
+
+    @wraps(func)
+    def retried_func(*args, **kwargs):
+        for no in range(RETRY_TIMES + 1):
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                logger.error(f'Error when calling `{func}`:')
+                logger.error(traceback.format_exc())
+
+                # Retried so many times but still errors - raise exception    
+                if no == RETRY_TIMES:
+                    raise e
+                
+            logger.info(f'Retrying {func} after {wait_secs}s...')
+            time.sleep(wait_secs)
+    
+    return retried_func

--- a/rafiki/predictor/constants.py
+++ b/rafiki/predictor/constants.py
@@ -24,6 +24,11 @@ class Query():
     def __init__(self, query: Any):
         self.id = str(uuid.uuid4())
         self.query = query
+    
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__
+                and self.id == other.id 
+                and self.query == other.query)
 
 class Prediction():
     def __init__(self, 
@@ -36,3 +41,9 @@ class Prediction():
         self.prediction = prediction
         self.query_id = query_id
         self.worker_id = worker_id
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__
+                and self.prediction == other.prediction 
+                and self.query_id == other.query_id
+                and self.worker_id == other.worker_id)

--- a/rafiki/predictor/predictor.py
+++ b/rafiki/predictor/predictor.py
@@ -42,8 +42,10 @@ class Predictor():
     def __init__(self, service_id, meta_store=None):
         self._service_id = service_id
         self._meta_store = meta_store or MetaStore()
-        self._redis_host = os.environ['REDIS_HOST']
-        self._redis_port = os.environ['REDIS_PORT']
+        self._redis_host = os.getenv('REDIS_HOST', 'rafiki_redis')
+        self._redis_port = os.getenv('REDIS_PORT', 6379)
+        self._kafka_host = os.getenv('KAFKA_HOST', 'rafiki_kafka')
+        self._kafka_port = os.getenv('KAFKA_PORT', 9092)
         self._ensemble_method: Callable[[List[Any]], Any] = None
         self._inference_job_id = None
 

--- a/rafiki/worker/inference.py
+++ b/rafiki/worker/inference.py
@@ -46,8 +46,10 @@ class InferenceWorker():
         self._worker_id = worker_id
         self._meta_store = meta_store or MetaStore()
         self._param_store = param_store or FileParamStore()
-        self._redis_host = os.environ['REDIS_HOST']
-        self._redis_port = os.environ['REDIS_PORT']
+        self._redis_host = os.getenv('REDIS_HOST', 'rafiki_redis')
+        self._redis_port = os.getenv('REDIS_PORT', 6379)
+        self._kafka_host = os.getenv('KAFKA_HOST', 'rafiki_kafka')
+        self._kafka_port = os.getenv('KAFKA_PORT', 9092)
         self._batch_size = PREDICT_BATCH_SIZE
         self._redis_cache: RedisInferenceCache = None
         self._inference_job_id = None

--- a/scripts/kubernetes/.env.sh
+++ b/scripts/kubernetes/.env.sh
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Cluster Mode for Rafiki
+export CLUSTER_MODE=SINGLE # CLUSTER or SINGLE
+
+# Core secrets for Rafiki - change these in production!
+export POSTGRES_PASSWORD=rafiki
+export SUPERADMIN_PASSWORD=rafiki
+export APP_SECRET=rafiki
+
+# Core external configuration for Rafiki
+export KUBERNETES_NETWORK=rafiki
+export KUBERNETES_ADVERTISE_ADDR=127.0.0.1
+export RAFIKI_VERSION=0.2.0
+export RAFIKI_ADDR=127.0.0.1
+export ADMIN_EXT_PORT=3000
+export WEB_ADMIN_EXT_PORT=3001
+export POSTGRES_EXT_PORT=5433
+export REDIS_EXT_PORT=6380
+export ZOOKEEPER_EXT_PORT=2181
+export KAFKA_EXT_PORT=9092
+export HOST_WORKDIR_PATH=$PWD
+export APP_MODE=DEV # DEV or PROD
+export POSTGRES_DUMP_FILE_PATH=$PWD/db_dump.sql # PostgreSQL database dump file
+export DOCKER_NODE_LABEL_AVAILABLE_GPUS=available_gpus # Docker node label for no. of services currently running on the node
+export DOCKER_NODE_LABEL_NUM_SERVICES=num_services # Docker node label for no. of services currently running on the node
+
+# Internal credentials for Rafiki's components
+export POSTGRES_USER=rafiki
+export POSTGRES_DB=rafiki
+export POSTGRES_STOLON_PASSWD=cmFmaWtpCg==  # The Passwd for stolon, base64 encode
+
+# Internal hosts & ports and configuration for Rafiki's components 
+export POSTGRES_HOST=rafiki-db
+export POSTGRES_PORT=5432
+export ADMIN_HOST=rafiki-admin
+export ADMIN_PORT=3000
+export REDIS_HOST=rafiki-redis
+export REDIS_PORT=6379
+export PREDICTOR_PORT=3003
+export WEB_ADMIN_HOST=rafiki-admin-web
+export ZOOKEEPER_HOST=rafiki-zookeeper
+export ZOOKEEPER_PORT=2181
+export KAFKA_HOST=rafiki-kafka
+export KAFKA_PORT=9092
+export DOCKER_WORKDIR_PATH=/root
+export DATA_DIR_PATH=data # Shares a data folder with containers, relative to workdir
+export LOGS_DIR_PATH=logs # Shares a folder with containers that stores components' logs, relative to workdir
+export PARAMS_DIR_PATH=params # Shares a folder with containers that stores model parameters, relative to workdir
+export CONDA_ENVIORNMENT=rafiki
+export WORKDIR_PATH=$HOST_WORKDIR_PATH # Specifying workdir if Python programs are run natively
+
+# Docker images for Rafiki's custom components
+export RAFIKI_IMAGE_ADMIN=rafikiai/rafiki_admin
+export RAFIKI_IMAGE_WEB_ADMIN=rafikiai/rafiki_admin_web
+export RAFIKI_IMAGE_WORKER=rafikiai/rafiki_worker
+export RAFIKI_IMAGE_PREDICTOR=rafikiai/rafiki_predictor
+export RAFIKI_IMAGE_STOLON=sorintlab/stolon:master-pg10
+
+# Docker images for dependent services
+export IMAGE_POSTGRES=postgres:10.5-alpine
+export IMAGE_REDIS=redis:5.0.3-alpine3.8
+export IMAGE_ZOOKEEPER=zookeeper:3.5
+export IMAGE_KAFKA=wurstmeister/kafka:2.12-2.1.1
+
+# Utility configuration
+export PYTHONPATH=$PWD # Ensures that `rafiki` module can be imported at project root
+export PYTHONUNBUFFERED=1 # Ensures logs from Python appear instantly 
+
+export CONTAINER_MODE=K8S
+
+if [ "$CLUSTER_MODE" = "CLUSTER" ]; then
+    export POSTGRES_HOST=stolon-proxy-service
+    export NFS_HOST_IP=127.0.0.1       # NFS Host IP - if used nfs as pv for database storage
+    export RUN_DIR_PATH=run            # Shares a folder with containers that stores components' running info, relative to workdir
+fi

--- a/scripts/kubernetes/create_config.py
+++ b/scripts/kubernetes/create_config.py
@@ -1,0 +1,355 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import json
+import sys
+import os
+
+if __name__ == '__main__':
+    POSTGRES_PASSWORD = sys.argv[1]
+    SUPERADMIN_PASSWORD = sys.argv[2]
+    APP_SECRET = sys.argv[3]
+    KUBERNETES_NETWORK = sys.argv[4]
+    KUBERNETES_ADVERTISE_ADDR = sys.argv[5]
+    RAFIKI_VERSION = sys.argv[6]
+    RAFIKI_ADDR = sys.argv[7]
+    ADMIN_EXT_PORT = sys.argv[8]
+    WEB_ADMIN_EXT_PORT = sys.argv[9]
+    POSTGRES_EXT_PORT = sys.argv[10]
+    REDIS_EXT_PORT = sys.argv[11]
+    ZOOKEEPER_EXT_PORT = sys.argv[12]
+    KAFKA_EXT_PORT = sys.argv[13]
+    HOST_WORKDIR_PATH = sys.argv[14]
+    APP_MODE = sys.argv[15] 
+    POSTGRES_DUMP_FILE_PATH = sys.argv[16] 
+    DOCKER_NODE_LABEL_AVAILABLE_GPUS = sys.argv[17] 
+    DOCKER_NODE_LABEL_NUM_SERVICES = sys.argv[18]
+
+    POSTGRES_USER = sys.argv[19]
+    POSTGRES_DB = sys.argv[20]
+ 
+    POSTGRES_HOST = sys.argv[21]
+    POSTGRES_PORT = sys.argv[22]
+    ADMIN_HOST = sys.argv[23]
+    ADMIN_PORT = sys.argv[24]
+    REDIS_HOST = sys.argv[25]
+    REDIS_PORT = sys.argv[26]
+    PREDICTOR_PORT = sys.argv[27]
+    WEB_ADMIN_HOST = sys.argv[28]
+    ZOOKEEPER_HOST = sys.argv[29]
+    ZOOKEEPER_PORT = sys.argv[30]
+    KAFKA_HOST = sys.argv[31]
+    KAFKA_PORT = sys.argv[32]
+    DOCKER_WORKDIR_PATH = sys.argv[33]
+    DATA_DIR_PATH = sys.argv[34] 
+    LOGS_DIR_PATH = sys.argv[35] 
+    PARAMS_DIR_PATH = sys.argv[36] 
+    CONDA_ENVIORNMENT = sys.argv[37]
+    WORKDIR_PATH = sys.argv[38] 
+
+    RAFIKI_IMAGE_ADMIN = sys.argv[39]
+    RAFIKI_IMAGE_WEB_ADMIN = sys.argv[40]
+    RAFIKI_IMAGE_WORKER = sys.argv[41]
+    RAFIKI_IMAGE_PREDICTOR = sys.argv[42]
+
+    IMAGE_POSTGRES = sys.argv[43]
+    IMAGE_REDIS = sys.argv[44]
+    IMAGE_ZOOKEEPER = sys.argv[45]
+    IMAGE_KAFKA = sys.argv[46]
+
+    PYTHONPATH = sys.argv[47] 
+    PYTHONUNBUFFERED = sys.argv[48]
+    CONTAINER_MODE = sys.argv[49]
+    CLUSTER_MODE = sys.argv[50]
+
+    #zk service
+    content = {}
+    content.setdefault('apiVersion', 'v1')
+    content.setdefault('kind', 'Service')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', ZOOKEEPER_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', ZOOKEEPER_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('type', 'NodePort')
+    ports = spec.setdefault('ports', [])
+    ports.append({'port': int(ZOOKEEPER_PORT), 'targetPort': int(ZOOKEEPER_PORT), 'nodePort': int(ZOOKEEPER_EXT_PORT)})
+    spec.setdefault('selector', {'name': ZOOKEEPER_HOST})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_zookeeper_service.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #zk deployment
+    content = {}
+    content.setdefault('apiVersion', 'apps/v1')      
+    content.setdefault('kind', 'Deployment')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', ZOOKEEPER_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', ZOOKEEPER_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('replicas', 1)
+    spec.setdefault('selector', {'matchLabels': {'name': ZOOKEEPER_HOST}})
+    template = spec.setdefault('template', {})
+    template.setdefault('metadata', {'labels': {'name': ZOOKEEPER_HOST}})
+    container = {}
+    container.setdefault('name', ZOOKEEPER_HOST)
+    container.setdefault('image', IMAGE_ZOOKEEPER)
+    env = []
+    env.append({'name': 'CONTAINER_MODE', 'value': CONTAINER_MODE})
+    container.setdefault('env', env)
+    template.setdefault('spec', {'containers': [container]})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_zookeeper_deployment.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #kafka service
+    content = {}
+    content.setdefault('apiVersion', 'v1')
+    content.setdefault('kind', 'Service')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', KAFKA_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', KAFKA_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('type', 'NodePort')
+    ports = spec.setdefault('ports', [])
+    ports.append({'port': int(KAFKA_PORT), 'targetPort': int(KAFKA_PORT), 'nodePort': int(KAFKA_EXT_PORT)})
+    spec.setdefault('selector', {'name': KAFKA_HOST})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_kafka_service.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #kafka deployment
+    content = {}
+    content.setdefault('apiVersion', 'apps/v1')      
+    content.setdefault('kind', 'Deployment')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', KAFKA_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', KAFKA_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('replicas', 1)
+    spec.setdefault('selector', {'matchLabels': {'name': KAFKA_HOST}})
+    template = spec.setdefault('template', {})
+    template.setdefault('metadata', {'labels': {'name': KAFKA_HOST}})
+    container = {}
+    container.setdefault('name', KAFKA_HOST)
+    container.setdefault('image', IMAGE_KAFKA)
+    env = []
+    env.append({'name': 'CONTAINER_MODE', 'value': CONTAINER_MODE})
+    env.append({'name': 'KAFKA_ZOOKEEPER_CONNECT', 'value': f'{ZOOKEEPER_HOST}:{ZOOKEEPER_PORT}'})
+    env.append({'name': 'KAFKA_ADVERTISED_HOST_NAME', 'value': KAFKA_HOST})
+    env.append({'name': 'KAFKA_ADVERTISED_PORT', 'value': KAFKA_PORT})
+    container.setdefault('env', env)
+    template.setdefault('spec', {'containers': [container]})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_kafka_deployment.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #db service
+    if CLUSTER_MODE == "SINGLE":
+        content = {}
+        content.setdefault('apiVersion', 'v1')
+        content.setdefault('kind', 'Service')
+        metadata = content.setdefault('metadata', {})
+        metadata.setdefault('name', POSTGRES_HOST)
+        labels = metadata.setdefault('labels', {})
+        labels.setdefault('name', POSTGRES_HOST)
+        spec = content.setdefault('spec', {})
+        spec.setdefault('type', 'NodePort')
+        ports = spec.setdefault('ports', [])
+        ports.append({'port': int(POSTGRES_PORT), 'targetPort': int(POSTGRES_PORT), 'nodePort': int(POSTGRES_EXT_PORT)})
+        spec.setdefault('selector', {'name': POSTGRES_HOST})
+        with open(f'{PYTHONPATH}/scripts/kubernetes/start_db_service.json', 'w') as f:
+            f.write(json.dumps(content, indent=4))
+
+        #db deployment
+        content = {}
+        content.setdefault('apiVersion', 'apps/v1')
+        content.setdefault('kind', 'Deployment')
+        metadata = content.setdefault('metadata', {})
+        metadata.setdefault('name', POSTGRES_HOST)
+        labels = metadata.setdefault('labels', {})
+        labels.setdefault('name', POSTGRES_HOST)
+        spec = content.setdefault('spec', {})
+        spec.setdefault('replicas', 1)
+        spec.setdefault('selector', {'matchLabels': {'name': POSTGRES_HOST}})
+        template = spec.setdefault('template', {})
+        template.setdefault('metadata', {'labels': {'name': POSTGRES_HOST}})
+        container = {}
+        container.setdefault('name', POSTGRES_HOST)
+        container.setdefault('image', IMAGE_POSTGRES)
+        env = []
+        env.append({'name': 'CONTAINER_MODE', 'value': CONTAINER_MODE})
+        env.append({'name': 'POSTGRES_HOST', 'value': POSTGRES_HOST})
+        env.append({'name': 'POSTGRES_PORT', 'value': POSTGRES_PORT})
+        env.append({'name': 'POSTGRES_PASSWORD', 'value': POSTGRES_PASSWORD})
+        container.setdefault('env', env)
+        template.setdefault('spec', {'containers': [container]})
+        with open(f'{PYTHONPATH}/scripts/kubernetes/start_db_deployment.json', 'w') as f:
+            f.write(json.dumps(content, indent=4))
+
+    #redis service
+    content = {}
+    content.setdefault('apiVersion', 'v1')
+    content.setdefault('kind', 'Service')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', REDIS_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', REDIS_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('type', 'NodePort')
+    ports = spec.setdefault('ports', [])
+    ports.append({'port': int(REDIS_PORT), 'targetPort': int(REDIS_PORT), 'nodePort': int(REDIS_EXT_PORT)})
+    spec.setdefault('selector', {'name': REDIS_HOST})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_redis_service.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #redis deployment
+    content = {}
+    content.setdefault('apiVersion', 'apps/v1')      
+    content.setdefault('kind', 'Deployment')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', REDIS_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', REDIS_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('replicas', 1)
+    spec.setdefault('selector', {'matchLabels':{'name': REDIS_HOST}})
+    template = spec.setdefault('template', {})
+    template.setdefault('metadata', {'labels': {'name': REDIS_HOST}})
+    container = {}
+    container.setdefault('name', REDIS_HOST)
+    container.setdefault('image', IMAGE_REDIS)
+    template.setdefault('spec', {'containers': [container]})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_redis_deployment.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #admin deployment
+    content = {}
+    content.setdefault('apiVersion', 'apps/v1')      
+    content.setdefault('kind', 'Deployment')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', ADMIN_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', ADMIN_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('replicas', 1)
+    spec.setdefault('selector', {'matchLabels': {'name': ADMIN_HOST}})
+    template = spec.setdefault('template', {})
+    template.setdefault('metadata', {'labels': {'name': ADMIN_HOST}})
+    container = {}
+    container.setdefault('name', ADMIN_HOST)
+    container.setdefault('image', f'{RAFIKI_IMAGE_ADMIN}:{RAFIKI_VERSION}')
+    if CONTAINER_MODE == 'DEV':
+        container.setdefault('volumeMounts', [{'name': ADMIN_HOST, 'mountPath': '/var/run/docker.sock'}, {'name': 'admin-log', 'mountPath': DOCKER_WORKDIR_PATH}])
+        template.setdefault('spec', {'containers': [container], 'volumes': [{'name': ADMIN_HOST, 'hostPath': {'path': '/var/run/docker.sock'}}, \
+                                    {'name': 'admin-log', 'hostPath': {'path': os.getenv('PWD', '')}}]})
+    else:
+        container.setdefault('volumeMounts', [{'name': 'work-path', 'mountPath': f'{DOCKER_WORKDIR_PATH}/{DATA_DIR_PATH}'}, \
+                                              {'name': 'param-path', 'mountPath': f'{DOCKER_WORKDIR_PATH}/{PARAMS_DIR_PATH}'}, \
+                                              {'name': 'log-path', 'mountPath': f'{DOCKER_WORKDIR_PATH}/{LOGS_DIR_PATH}'}, \
+                                              {'name': ADMIN_HOST, 'mountPath': '/var/run/docker.sock'}])
+        template.setdefault('spec', {'containers': [container], 'volumes': [{'name': 'work-path', 'hostPath': {'path': f'{HOST_WORKDIR_PATH}/{DATA_DIR_PATH}'}}, \
+                                    {'name': 'param-path', 'hostPath': {'path': f'{HOST_WORKDIR_PATH}/{PARAMS_DIR_PATH}'}}, \
+                                    {'name': 'log-path', 'hostPath': {'path': f'{HOST_WORKDIR_PATH}/{LOGS_DIR_PATH}'}}, \
+                                    {'name': ADMIN_HOST, 'hostPath': {'path': '/var/run/docker.sock'}}]})
+    env = []
+    env.append({'name': 'POSTGRES_HOST', 'value': POSTGRES_HOST})
+    env.append({'name': 'POSTGRES_PORT', 'value': POSTGRES_PORT})
+    env.append({'name': 'POSTGRES_USER', 'value': POSTGRES_USER})
+    env.append({'name': 'POSTGRES_DB', 'value': POSTGRES_DB})
+    env.append({'name': 'POSTGRES_PASSWORD', 'value': POSTGRES_PASSWORD})
+    env.append({'name': 'SUPERADMIN_PASSWORD', 'value': SUPERADMIN_PASSWORD})
+    env.append({'name': 'ADMIN_HOST', 'value': ADMIN_HOST})
+    env.append({'name': 'ADMIN_PORT', 'value': ADMIN_PORT})
+    env.append({'name': 'REDIS_HOST', 'value': REDIS_HOST})
+    env.append({'name': 'REDIS_PORT', 'value': REDIS_PORT})
+    env.append({'name': 'KAFKA_HOST', 'value': KAFKA_HOST})
+    env.append({'name': 'KAFKA_PORT', 'value': KAFKA_PORT})
+    env.append({'name': 'PREDICTOR_PORT', 'value': PREDICTOR_PORT})
+    env.append({'name': 'RAFIKI_ADDR', 'value': RAFIKI_ADDR})
+    env.append({'name': 'RAFIKI_IMAGE_WORKER', 'value': RAFIKI_IMAGE_WORKER})
+    env.append({'name': 'RAFIKI_IMAGE_PREDICTOR', 'value': RAFIKI_IMAGE_PREDICTOR})
+    env.append({'name': 'RAFIKI_VERSION', 'value': RAFIKI_VERSION})
+    env.append({'name': 'DOCKER_WORKDIR_PATH', 'value': DOCKER_WORKDIR_PATH})
+    env.append({'name': 'WORKDIR_PATH', 'value': DOCKER_WORKDIR_PATH})
+    env.append({'name': 'HOST_WORKDIR_PATH', 'value': HOST_WORKDIR_PATH})
+    env.append({'name': 'DATA_DIR_PATH', 'value': DATA_DIR_PATH})
+    env.append({'name': 'PARAMS_DIR_PATH', 'value': PARAMS_DIR_PATH})
+    env.append({'name': 'LOGS_DIR_PATH', 'value': LOGS_DIR_PATH})
+    env.append({'name': 'APP_MODE', 'value': APP_MODE})
+    env.append({'name': 'CONTAINER_MODE', 'value': CONTAINER_MODE})
+    container.setdefault('env', env)
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_admin_deployment.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #admin service
+    content = {}
+    content.setdefault('apiVersion', 'v1')
+    content.setdefault('kind', 'Service')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', ADMIN_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', ADMIN_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('type', 'NodePort')
+    ports = spec.setdefault('ports', [])
+    ports.append({'port': int(ADMIN_PORT), 'targetPort': int(ADMIN_PORT), 'nodePort': int(ADMIN_EXT_PORT)})
+    spec.setdefault('selector', {'name': ADMIN_HOST})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_admin_service.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #web service
+    content = {}
+    content.setdefault('apiVersion', 'v1')
+    content.setdefault('kind', 'Service')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', WEB_ADMIN_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', WEB_ADMIN_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('type', 'NodePort')
+    ports = spec.setdefault('ports', [])
+    ports.append({'port': int(3001), 'targetPort': int(3001), 'nodePort': int(WEB_ADMIN_EXT_PORT)})
+    spec.setdefault('selector', {'name': WEB_ADMIN_HOST})
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_web_admin_service.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+
+    #web deployment
+    content = {}
+    content.setdefault('apiVersion', 'apps/v1')      
+    content.setdefault('kind', 'Deployment')
+    metadata = content.setdefault('metadata', {})
+    metadata.setdefault('name', WEB_ADMIN_HOST)
+    labels = metadata.setdefault('labels', {})
+    labels.setdefault('name', WEB_ADMIN_HOST)
+    spec = content.setdefault('spec', {})
+    spec.setdefault('replicas', 1)
+    spec.setdefault('selector', {'matchLabels': {'name': WEB_ADMIN_HOST}})
+    template = spec.setdefault('template', {})
+    template.setdefault('metadata', {'labels': {'name': WEB_ADMIN_HOST}})
+    container = {}
+    container.setdefault('name', WEB_ADMIN_HOST)
+    container.setdefault('image', f'{RAFIKI_IMAGE_WEB_ADMIN}:{RAFIKI_VERSION}')
+    template.setdefault('spec', {'containers': [container]})
+    env = []
+    env.append({'name': 'RAFIKI_ADDR', 'value': RAFIKI_ADDR})
+    env.append({'name': 'ADMIN_EXT_PORT', 'value': ADMIN_EXT_PORT})
+    container.setdefault('env', env)
+    with open(f'{PYTHONPATH}/scripts/kubernetes/start_web_admin_deployment.json', 'w') as f:
+        f.write(json.dumps(content, indent=4))
+

--- a/scripts/kubernetes/create_nfs_pv.sh
+++ b/scripts/kubernetes/create_nfs_pv.sh
@@ -1,0 +1,20 @@
+if [ $# -lt 8 ]; then
+    echo "usage:
+         $0: <pv-name> <nfs-ip> <path> <storage> <accessModes> <reclaimPolicy> <lables_key> <lables_value>
+         eg: $0 stolon-db-pv1 192.168.100.103 /home/rafiki/database/db1 100Gi ReadWriteOnce Retain"
+    exit 1
+fi
+
+TMP_NFS_PV_YAML=scripts/kubernetes/tmp-nfs-pv.yaml
+cp scripts/kubernetes/nfs-pv.yaml.template $TMP_NFS_PV_YAML
+sed -ri "s/PV_NAME/$1/g" $TMP_NFS_PV_YAML
+sed -ri "s/PV_IP/$2/g" $TMP_NFS_PV_YAML
+sed -ri "s#PV_PATH#$3/#" $TMP_NFS_PV_YAML
+sed -ri "s/PV_STORAGE/$4/g" $TMP_NFS_PV_YAML
+sed -ri "s/PV_ACCESS_MODES/$5/g" $TMP_NFS_PV_YAML
+sed -ri "s/PV_RECLAIN_POLICY/$6/g" $TMP_NFS_PV_YAML
+sed -ri "s/LABLES_KEYS_0/$7/g" $TMP_NFS_PV_YAML
+sed -ri "s/LABLES_VALUES_0/$8/g" $TMP_NFS_PV_YAML
+
+kubectl create -f $TMP_NFS_PV_YAML
+rm -f $TMP_NFS_PV_YAML

--- a/scripts/kubernetes/create_nfs_pvc.sh
+++ b/scripts/kubernetes/create_nfs_pvc.sh
@@ -1,0 +1,17 @@
+if [ $# -lt 5 ]; then
+    echo "usage:
+         $0: <pvc-name> <storage> <accessModes> <lables_key> <lables_value>
+         eg: $0 database-stolon-keeper-0 100Gi ReadWriteOnce pv database-pv-0"
+    exit 1
+fi
+
+TMP_NFS_PVC_YAML=scripts/kubernetes/tmp-nfs-pvc.yaml
+cp scripts/kubernetes/nfs-pvc.yaml.template $TMP_NFS_PVC_YAML
+sed -ri "s/PVC_NAME/$1/g" $TMP_NFS_PVC_YAML
+sed -ri "s/PV_STORAGE/$2/g" $TMP_NFS_PVC_YAML
+sed -ri "s/PV_ACCESS_MODES/$3/g" $TMP_NFS_PVC_YAML
+sed -ri "s/LABLES_KEYS_0/$4/g" $TMP_NFS_PVC_YAML
+sed -ri "s/LABLES_VALUES_0/$5/g" $TMP_NFS_PVC_YAML
+
+kubectl create -f $TMP_NFS_PVC_YAML
+rm -f $TMP_NFS_PVC_YAML

--- a/scripts/kubernetes/generate_config.sh
+++ b/scripts/kubernetes/generate_config.sh
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+source ./scripts/kubernetes/.env.sh
+
+python3 ./scripts/kubernetes/create_config.py \
+$POSTGRES_PASSWORD \
+$SUPERADMIN_PASSWORD \
+$APP_SECRET \
+$KUBERNETES_NETWORK \
+$KUBERNETES_ADVERTISE_ADDR \
+$RAFIKI_VERSION \
+$RAFIKI_ADDR \
+$ADMIN_EXT_PORT \
+$WEB_ADMIN_EXT_PORT \
+$POSTGRES_EXT_PORT \
+$REDIS_EXT_PORT \
+$ZOOKEEPER_EXT_PORT \
+$KAFKA_EXT_PORT \
+$HOST_WORKDIR_PATH \
+$APP_MODE \
+$POSTGRES_DUMP_FILE_PATH \
+$DOCKER_NODE_LABEL_AVAILABLE_GPUS \
+$DOCKER_NODE_LABEL_NUM_SERVICES \
+$POSTGRES_USER \
+$POSTGRES_DB \
+$POSTGRES_HOST \
+$POSTGRES_PORT \
+$ADMIN_HOST \
+$ADMIN_PORT \
+$REDIS_HOST \
+$REDIS_PORT \
+$PREDICTOR_PORT \
+$WEB_ADMIN_HOST \
+$ZOOKEEPER_HOST \
+$ZOOKEEPER_PORT \
+$KAFKA_HOST \
+$KAFKA_PORT \
+$DOCKER_WORKDIR_PATH \
+$DATA_DIR_PATH \
+$LOGS_DIR_PATH \
+$PARAMS_DIR_PATH \
+$CONDA_ENVIORNMENT \
+$WORKDIR_PATH \
+$RAFIKI_IMAGE_ADMIN \
+$RAFIKI_IMAGE_WEB_ADMIN \
+$RAFIKI_IMAGE_WORKER \
+$RAFIKI_IMAGE_PREDICTOR \
+$IMAGE_POSTGRES \
+$IMAGE_REDIS \
+$IMAGE_ZOOKEEPER \
+$IMAGE_KAFKA \
+$PYTHONPATH \
+$PYTHONUNBUFFERED \
+$CONTAINER_MODE \
+$CLUSTER_MODE

--- a/scripts/kubernetes/load_db.sh
+++ b/scripts/kubernetes/load_db.sh
@@ -17,6 +17,20 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/.env.sh
+DUMP_FILE=$POSTGRES_DUMP_FILE_PATH
+
+source ./scripts/kubernetes/utils.sh
+
+title "Maybe loading from database dump..." 
+
+# Check if dump file exists
+if [ -f $DUMP_FILE ]
+then 
+    echo "Loading database dump at $DUMP_FILE..." 
+    DB_PODNAME=$(kubectl get pod | grep $POSTGRES_HOST)
+    DB_PODNAME=${DB_PODNAME:0:26}
+    cat $DUMP_FILE | kubectl exec -i $DB_PODNAME -c $POSTGRES_HOST -- psql -U postgres --dbname $POSTGRES_DB > /dev/null
+else
+    echo "No database dump file found." 
+fi

--- a/scripts/kubernetes/nfs-pv.yaml.template
+++ b/scripts/kubernetes/nfs-pv.yaml.template
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: PV_NAME
+  labels:
+    LABLES_KEYS_0: LABLES_VALUES_0
+    type: nfs
+spec:
+  capacity:
+    storage: PV_STORAGE
+#  storageClassName: "PostgreSQLStorageClass"
+  accessModes:
+    - PV_ACCESS_MODES
+  persistentVolumeReclaimPolicy: PV_RECLAIN_POLICY
+  nfs:
+    server: PV_IP
+    path: "PV_PATH"

--- a/scripts/kubernetes/nfs-pvc.yaml.template
+++ b/scripts/kubernetes/nfs-pvc.yaml.template
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: PVC_NAME
+spec:
+  accessModes:
+    - PV_ACCESS_MODES
+  resources:
+    requests:
+      storage: PV_STORAGE
+  selector:
+    matchLabels:
+      LABLES_KEYS_0: LABLES_VALUES_0
+    

--- a/scripts/kubernetes/pull_images.sh
+++ b/scripts/kubernetes/pull_images.sh
@@ -17,6 +17,26 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/utils.sh
+
+pull_image()
+{
+    if [[ ! -z $(docker images -q $1) ]]
+    then
+        echo "$1 already exists locally"
+    else 
+        docker pull $1 || exit 1 
+    fi
+}
+
+title "Pulling images..."
+echo "Pulling images required by Rafiki from Docker Hub..."
+pull_image $IMAGE_POSTGRES
+pull_image $IMAGE_REDIS
+pull_image $IMAGE_KAFKA
+pull_image $IMAGE_ZOOKEEPER
+pull_image $RAFIKI_IMAGE_ADMIN:$RAFIKI_VERSION
+pull_image $RAFIKI_IMAGE_WORKER:$RAFIKI_VERSION
+pull_image $RAFIKI_IMAGE_PREDICTOR:$RAFIKI_VERSION
+pull_image $RAFIKI_IMAGE_WEB_ADMIN:$RAFIKI_VERSION
+pull_image $RAFIKI_IMAGE_STOLON

--- a/scripts/kubernetes/remove_config.sh
+++ b/scripts/kubernetes/remove_config.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+rm -f ./scripts/kubernetes/start_admin_deployment.json
+rm -f ./scripts/kubernetes/start_redis_deployment.json
+rm -f ./scripts/kubernetes/start_web_admin_deployment.json
+rm -f ./scripts/kubernetes/start_db_deployment.json
+rm -f ./scripts/kubernetes/start_zookeeper_deployment.json
+rm -f ./scripts/kubernetes/start_kafka_deployment.json
+
+rm -f ./scripts/kubernetes/start_admin_service.json
+rm -f ./scripts/kubernetes/start_redis_service.json
+rm -f ./scripts/kubernetes/start_web_admin_service.json
+rm -f ./scripts/kubernetes/start_db_service.json
+rm -f ./scripts/kubernetes/start_zookeeper_service.json
+rm -f ./scripts/kubernetes/start_kafka_service.json

--- a/scripts/kubernetes/start.sh
+++ b/scripts/kubernetes/start.sh
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+source ./scripts/kubernetes/utils.sh
+
+# Read from shell configuration file
+source ./scripts/kubernetes/.env.sh
+
+# ensure python api in pod has auth to control kubernetes
+kubectl create clusterrolebinding add-on-cluster-admin \
+    --clusterrole=cluster-admin --serviceaccount=default:default
+
+# Pull images from Docker Hub
+bash ./scripts/kubernetes/pull_images.sh || exit 1
+
+# Generate config files
+bash ./scripts/kubernetes/generate_config.sh || exit 1
+
+# Start whole Rafiki stack
+# Start Zookeeper, Kafka & Redis
+bash ./scripts/kubernetes/start_zookeeper.sh || exit 1
+bash ./scripts/kubernetes/start_kafka.sh || exit 1
+bash ./scripts/kubernetes/start_redis.sh || exit 1
+
+# Skip starting & loading DB if DB is already running
+if [ "$CLUSTER_MODE" = "SINGLE" ]; then
+    if is_running $POSTGRES_HOST
+    then
+      echo "Detected that Rafiki's DB is already running!"
+    else
+        bash ./scripts/kubernetes/start_db.sh || exit 1
+        bash ./scripts/kubernetes/load_db.sh || exit 1
+    fi
+else
+    # Whether stolon has started inside the script
+    bash ./scripts/kubernetes/start_stolon.sh || exit 1
+fi
+
+bash ./scripts/kubernetes/start_admin.sh || exit 1
+bash ./scripts/kubernetes/start_web_admin.sh || exit 1
+
+bash ./scripts/kubernetes/remove_config.sh || exit 1
+
+echo "To use Rafiki, use Rafiki Client in the Python CLI"
+echo "A quickstart is available at https://nginyc.github.io/rafiki/docs/latest/docs/src/user/quickstart.html"
+echo "To configure Rafiki, refer to Rafiki's developer docs at https://nginyc.github.io/rafiki/docs/latest/docs/src/dev/setup.html"
+

--- a/scripts/kubernetes/start_admin.sh
+++ b/scripts/kubernetes/start_admin.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's Admin..."
+
+LOG_FILE_PATH=$PWD/logs/start_admin_service.log
+(kubectl create -f scripts/kubernetes/start_admin_service.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Admin Service" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_admin_deployment.log
+(kubectl create -f scripts/kubernetes/start_admin_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Admin Deployment" $LOG_FILE_PATH 20

--- a/scripts/kubernetes/start_db.sh
+++ b/scripts/kubernetes/start_db.sh
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's DB..."
+
+LOG_FILE_PATH=$PWD/logs/start_db_service.log
+(kubectl create -f scripts/kubernetes/start_db_service.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's DB Service" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_db_deployment.log
+(kubectl create -f scripts/kubernetes/start_db_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's DB Deployment" $LOG_FILE_PATH 20
+
+echo "Creating Rafiki's PostgreSQL database & user..."
+DB_PODNAME=$(kubectl get pod | grep $POSTGRES_HOST)
+DB_PODNAME=${DB_PODNAME:0:26}
+kubectl exec $DB_PODNAME -c $POSTGRES_HOST -- psql -U postgres -c "CREATE DATABASE $POSTGRES_DB"
+kubectl exec $DB_PODNAME -c $POSTGRES_HOST -- psql -U postgres -c "CREATE USER $POSTGRES_USER WITH PASSWORD '$POSTGRES_PASSWORD'"

--- a/scripts/kubernetes/start_kafka.sh
+++ b/scripts/kubernetes/start_kafka.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's Kafka..."
+
+LOG_FILE_PATH=$PWD/logs/start_kafka_service.log
+(kubectl create -f scripts/kubernetes/start_kafka_service.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Kafka Service" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_kafka_deployment.log
+(kubectl create -f scripts/kubernetes/start_kafka_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Kafka Deployment" $LOG_FILE_PATH 10

--- a/scripts/kubernetes/start_redis.sh
+++ b/scripts/kubernetes/start_redis.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's Redis..."
+
+LOG_FILE_PATH=$PWD/logs/start_redis_service.log
+(kubectl create -f scripts/kubernetes/start_redis_service.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Redis Service" $LOG_FILE_PATH 10
+
+LOG_FILE_PATH=$PWD/logs/start_redis_deployment.log
+(kubectl create -f scripts/kubernetes/start_redis_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Redis Deployment" $LOG_FILE_PATH 10

--- a/scripts/kubernetes/start_stolon.sh
+++ b/scripts/kubernetes/start_stolon.sh
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+source ./scripts/kubernetes/.env.sh
+source ./scripts/kubernetes/utils.sh
+
+DB_CLUSTER_RUNNING_FILE=$HOST_WORKDIR_PATH/$RUN_DIR_PATH/DB-CLUSTER-RUNNING
+mkdir -p $HOST_WORKDIR_PATH/$RUN_DIR_PATH/
+
+title "Starting Rafiki's DB..."
+if [ -f $DB_CLUSTER_RUNNING_FILE ]; then
+    echo "Rafiki's DB is already running, skip..."
+    exit 0
+fi
+
+echo "Create PV..."
+# With stolon, we use some default parameters to make nfs as pv, if your have another choice or want to change the default parameters,
+# your should modify this script
+bash scripts/kubernetes/create_nfs_pv.sh database-pv-0 $NFS_HOST_IP /home/rafiki/database/db0 100Gi ReadWriteOnce Retain pv database-pv-0
+bash scripts/kubernetes/create_nfs_pv.sh database-pv-1 $NFS_HOST_IP /home/rafiki/database/db1 100Gi ReadWriteOnce Retain pv database-pv-1
+echo "Create PVC..."
+# PVC Name is Fixed
+bash scripts/kubernetes/create_nfs_pvc.sh database-stolon-keeper-0 100Gi ReadWriteOnce pv database-pv-0
+bash scripts/kubernetes/create_nfs_pvc.sh database-stolon-keeper-1 100Gi ReadWriteOnce pv database-pv-1
+
+bash scripts/kubernetes/stolon/generate_stolon_yaml.sh
+LOG_FILE_PATH=$PWD/logs/start_stolon_sentinel.log
+(kubectl create -f scripts/kubernetes/stolon/stolon-sentinel.yaml \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Stolon Sentinel" $LOG_FILE_PATH 20
+
+kubectl create -f scripts/kubernetes/stolon/secret.yaml
+
+LOG_FILE_PATH=$PWD/logs/start_stolon_keeper.log
+(kubectl create -f scripts/kubernetes/stolon/stolon-keeper.yaml \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Stolon Keeper" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_stolon_proxy.log
+(kubectl create -f scripts/kubernetes/stolon/stolon-proxy.yaml \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Stolon Proxy" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_stolon_proxy_service.log
+(kubectl create -f scripts/kubernetes/stolon/stolon-proxy-service.yaml \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Stolon Proxy Service" $LOG_FILE_PATH 10
+
+DB_CLUSTER_INIT_FILE=$HOST_WORKDIR_PATH/$RUN_DIR_PATH/DB-CLUSTER-INIT-FLAG-CAN-NOT-REMOVE
+if [ -f $DB_CLUSTER_INIT_FILE ]; then
+    echo "The Database Cluster already initialized, don't need reinitialize ..."
+    echo "Waiting for 60s for Rafiki's Stolon Cluster to stabilize..."
+    sleep 60
+else
+    echo "Create databse initialized file $DB_CLUSTER_INIT_FILE"
+    touch $DB_CLUSTER_INIT_FILE
+    echo "Attention: The file `basename $DB_CLUSTER_INIT_FILE` can not be removed, otherwise your will 
+        lost your databse data after exec $0 next time." > $DB_CLUSTER_INIT_FILE
+    echo -e "\033[31m`cat $DB_CLUSTER_INIT_FILE` \033[0m"
+    date >> $DB_CLUSTER_INIT_FILE
+
+    kubectl run -i -t stolon-init-cluster --image=$RAFIKI_IMAGE_STOLON \
+      --restart=Never --rm -- /usr/local/bin/stolonctl \
+      --cluster-name=kube-stolon --store-backend=kubernetes \
+      --kube-resource-kind=configmap init -y
+    echo "Waiting for 60s for Rafiki's Stolon Cluster to stabilize..."
+    sleep 60
+    
+    echo "Creating Rafiki's PostgreSQL database & user..."
+    DB_SVC_IP=`kubectl get svc | grep stolon-proxy-service | awk '{print $3}'`
+    STOLON_PASSWD=`echo $POSTGRES_STOLON_PASSWD|base64 -d`
+    kubectl run -i -t stolon-create-db --image=$RAFIKI_IMAGE_STOLON \
+      --restart=Never --env="PGPASSWORD=$STOLON_PASSWD" --rm -- psql -h $DB_SVC_IP postgres -U stolon -c "CREATE DATABASE $POSTGRES_DB"
+    kubectl run -i -t stolon-create-user --image=$RAFIKI_IMAGE_STOLON \
+      --restart=Never --env="PGPASSWORD=$STOLON_PASSWD" --rm -- psql -h $DB_SVC_IP postgres -U stolon -c "CREATE USER $POSTGRES_USER WITH PASSWORD '$POSTGRES_PASSWORD'"
+fi
+
+touch $DB_CLUSTER_RUNNING_FILE
+echo "Create databse running file $DB_CLUSTER_RUNNING_FILE"

--- a/scripts/kubernetes/start_web_admin.sh
+++ b/scripts/kubernetes/start_web_admin.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's Web Admin..."
+
+LOG_FILE_PATH=$PWD/logs/start_web_admin_service.log
+(kubectl create -f ./scripts/kubernetes/start_web_admin_service.json \
+  &> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Web Admin Service" $LOG_FILE_PATH 10
+
+LOG_FILE_PATH=$PWD/logs/start_web_admin_deployment.log
+(kubectl create -f scripts/kubernetes/start_web_admin_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Web Admin Deployment" $LOG_FILE_PATH 10

--- a/scripts/kubernetes/start_zookeeper.sh
+++ b/scripts/kubernetes/start_zookeeper.sh
@@ -17,6 +17,16 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+source ./scripts/kubernetes/utils.sh
+
+title "Starting Rafiki's Zookeeper..."
+
+LOG_FILE_PATH=$PWD/logs/start_zookeeper_service.log
+(kubectl create -f scripts/kubernetes/start_zookeeper_service.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Zookeeper Service" $LOG_FILE_PATH 20
+
+LOG_FILE_PATH=$PWD/logs/start_zookeeper_deployment.log
+(kubectl create -f scripts/kubernetes/start_zookeeper_deployment.json \
+&> $LOG_FILE_PATH) &
+ensure_stable "Rafiki's Zookeeper Deployment" $LOG_FILE_PATH 10

--- a/scripts/kubernetes/stolon/generate_stolon_yaml.sh
+++ b/scripts/kubernetes/stolon/generate_stolon_yaml.sh
@@ -1,0 +1,22 @@
+STOLON_PATH=scripts/kubernetes/stolon
+cp -f $STOLON_PATH/secret.yaml.template $STOLON_PATH/secret.yaml
+sed -ri "s/STOLON_PASSWD/$POSTGRES_STOLON_PASSWD/g" $STOLON_PATH/secret.yaml
+
+# replace config for stolon keeper
+cp -f $STOLON_PATH/stolon-keeper.yaml.template         $STOLON_PATH/stolon-keeper.yaml
+sed -ri "s#RAFIKI_IMAGE_STOLON#$RAFIKI_IMAGE_STOLON#"  $STOLON_PATH/stolon-keeper.yaml
+sed -ri "s/POSTGRES_PORT/$POSTGRES_PORT/g"             $STOLON_PATH/stolon-keeper.yaml
+
+# replace config for stolon proxy
+cp -f $STOLON_PATH/stolon-proxy.yaml.template          $STOLON_PATH/stolon-proxy.yaml
+sed -ri "s#RAFIKI_IMAGE_STOLON#$RAFIKI_IMAGE_STOLON#"  $STOLON_PATH/stolon-proxy.yaml
+sed -ri "s/POSTGRES_PORT/$POSTGRES_PORT/g"             $STOLON_PATH/stolon-proxy.yaml
+
+# replace config for stolon sentinel
+cp -f $STOLON_PATH/stolon-sentinel.yaml.template       $STOLON_PATH/stolon-sentinel.yaml
+sed -ri "s#RAFIKI_IMAGE_STOLON#$RAFIKI_IMAGE_STOLON#"  $STOLON_PATH/stolon-sentinel.yaml
+
+# replace config for stolon proxy service
+cp -f $STOLON_PATH/stolon-proxy-service.yaml.template  $STOLON_PATH/stolon-proxy-service.yaml
+sed -ri "s/POSTGRES_EXT_PORT/$POSTGRES_EXT_PORT/g"     $STOLON_PATH/stolon-proxy-service.yaml
+sed -ri "s/POSTGRES_PORT/$POSTGRES_PORT/g"             $STOLON_PATH/stolon-proxy-service.yaml

--- a/scripts/kubernetes/stolon/secret.yaml.template
+++ b/scripts/kubernetes/stolon/secret.yaml.template
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: stolon
+type: Opaque
+data:
+    password: STOLON_PASSWD

--- a/scripts/kubernetes/stolon/stolon-keeper.yaml.template
+++ b/scripts/kubernetes/stolon/stolon-keeper.yaml.template
@@ -1,0 +1,88 @@
+# PetSet was renamed to StatefulSet in k8s 1.5
+# apiVersion: apps/v1alpha1
+# kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: stolon-keeper
+spec:
+  serviceName: "stolon-keeper"
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: stolon-keeper
+        stolon-cluster: kube-stolon
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: stolon-keeper
+        image: RAFIKI_IMAGE_STOLON
+        command:
+          - "/bin/bash"
+          - "-ec"
+          - |
+            # Generate our keeper uid using the pod index
+            IFS='-' read -ra ADDR <<< "$(hostname)"
+            export STKEEPER_UID="keeper${ADDR[-1]}"
+            export POD_IP=$(hostname -i)
+            export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
+            export STOLON_DATA=/stolon-data
+            chown stolon:stolon $STOLON_DATA
+            #chown postgres:postgres $STOLON_DATA
+            exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: STKEEPER_CLUSTER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['stolon-cluster']
+          - name: STKEEPER_STORE_BACKEND
+            value: "kubernetes"
+          - name: STKEEPER_KUBE_RESOURCE_KIND
+            value: "configmap"
+          - name: STKEEPER_PG_REPL_USERNAME
+            value: "repluser"
+            # Or use a password file like in the below supersuser password
+          - name: STKEEPER_PG_REPL_PASSWORD
+            value: "replpassword"
+          - name: STKEEPER_PG_SU_USERNAME
+            value: "stolon"
+          - name: STKEEPER_PG_SU_PASSWORDFILE
+            value: "/etc/secrets/stolon/password"
+          - name: STKEEPER_METRICS_LISTEN_ADDRESS
+            value: "0.0.0.0:8080"
+          # Uncomment this to enable debug logs
+          #- name: STKEEPER_DEBUG
+          #  value: "true"
+        ports:
+          - containerPort: POSTGRES_PORT
+          - containerPort: 8080
+        volumeMounts:
+        - mountPath: /stolon-data
+          name: database
+        - mountPath: /etc/secrets/stolon
+          name: stolon
+      volumes:
+        - name: stolon
+          secret:
+            secretName: stolon
+  # Define your own volumeClaimTemplate. This example uses dynamic PV provisioning with a storage class named "standard" (so it will works by default with minikube)
+  # In production you should use your own defined storage-class and configure your persistent volumes (statically or dynamically using a provisioner, see related k8s doc).
+  volumeClaimTemplates:
+  - metadata:
+      name: database
+      #annotations:
+      #  volume.alpha.kubernetes.io/storage-class: standard
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 100Gi

--- a/scripts/kubernetes/stolon/stolon-proxy-service.yaml.template
+++ b/scripts/kubernetes/stolon/stolon-proxy-service.yaml.template
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stolon-proxy-service
+spec:
+  type: NodePort
+  ports:
+    - port: POSTGRES_PORT
+      targetPort: POSTGRES_PORT
+      nodePort: POSTGRES_EXT_PORT
+  selector:
+    component: stolon-proxy
+    stolon-cluster: kube-stolon

--- a/scripts/kubernetes/stolon/stolon-proxy.yaml.template
+++ b/scripts/kubernetes/stolon/stolon-proxy.yaml.template
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: stolon-proxy
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: stolon-proxy
+        stolon-cluster: kube-stolon
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+      - name: stolon-proxy
+        image: RAFIKI_IMAGE_STOLON
+        command:
+          - "/bin/bash"
+          - "-ec"
+          - |
+            exec gosu stolon stolon-proxy
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: STPROXY_CLUSTER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['stolon-cluster']
+          - name: STPROXY_STORE_BACKEND
+            value: "kubernetes"
+          - name: STPROXY_KUBE_RESOURCE_KIND
+            value: "configmap"
+          - name: STPROXY_LISTEN_ADDRESS
+            value: "0.0.0.0"
+          - name: STPROXY_METRICS_LISTEN_ADDRESS
+            value: "0.0.0.0:8080"
+          ## Uncomment this to enable debug logs
+          #- name: STPROXY_DEBUG
+          #  value: "true"
+        ports:
+          - containerPort: POSTGRES_PORT
+          - containerPort: 8080
+        readinessProbe:
+          tcpSocket:
+            port: POSTGRES_PORT
+          initialDelaySeconds: 10
+          timeoutSeconds: 5

--- a/scripts/kubernetes/stolon/stolon-sentinel.yaml.template
+++ b/scripts/kubernetes/stolon/stolon-sentinel.yaml.template
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: stolon-sentinel
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: stolon-sentinel
+        stolon-cluster: kube-stolon
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+      - name: stolon-sentinel
+        image: RAFIKI_IMAGE_STOLON
+        command:
+          - "/bin/bash"
+          - "-ec"
+          - |
+            exec gosu stolon stolon-sentinel
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: STSENTINEL_CLUSTER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['stolon-cluster']
+          - name: STSENTINEL_STORE_BACKEND
+            value: "kubernetes"
+          - name: STSENTINEL_KUBE_RESOURCE_KIND
+            value: "configmap"
+          - name: STSENTINEL_METRICS_LISTEN_ADDRESS
+            value: "0.0.0.0:8080"
+          ## Uncomment this to enable debug logs
+          #- name: STSENTINEL_DEBUG
+          #  value: "true"
+        ports:
+          - containerPort: 8080

--- a/scripts/kubernetes/stop.sh
+++ b/scripts/kubernetes/stop.sh
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+source ./scripts/kubernetes/.env.sh
+
+source ./scripts/kubernetes/utils.sh
+
+title "Stopping any existing jobs..."
+python ./scripts/stop_all_jobs.py
+
+title "Stopping Rafiki's Web Admin Deployment..."
+kubectl delete deployment $WEB_ADMIN_HOST || echo "Failed to stop Rafiki's Web Admin Deployment"
+
+title "Stopping Rafiki's Admin Deployment..."
+kubectl delete deployment $ADMIN_HOST || echo "Failed to stop Rafiki's Admin Deployment"
+
+title "Stopping Rafiki's Redis Deployment..."
+kubectl delete deployment $REDIS_HOST || echo "Failed to stop Rafiki's Redis Deployment"
+
+title "Stopping Rafiki's Kafka Deployment..."
+kubectl delete deployment $KAFKA_HOST || echo "Failed to stop Rafiki's Kafka Deployment"
+
+title "Stopping Rafiki's Zookeeper Deployment..."
+kubectl delete deployment $ZOOKEEPER_HOST || echo "Failed to stop Rafiki's Zookeeper Deployment"
+
+title "Stopping Rafiki's Web Admin Service..."
+kubectl delete service $WEB_ADMIN_HOST || echo "Failed to stop Rafiki's Web Admin Service"
+
+title "Stopping Rafiki's Admin Service..."
+kubectl delete service $ADMIN_HOST || echo "Failed to stop Rafiki's Admin Service"
+
+title "Stopping Rafiki's Redis Service..."
+kubectl delete service $REDIS_HOST || echo "Failed to stop Rafiki's Redis Service"
+
+title "Stopping Rafiki's Kafka Service..."
+kubectl delete service $KAFKA_HOST || echo "Failed to stop Rafiki's Kafka Service"
+
+title "Stopping Rafiki's Zookeeper Service..."
+kubectl delete service $ZOOKEEPER_HOST || echo "Failed to stop Rafiki's Zookeeper Service"
+
+# Prompt if should stop DB
+if prompt "Should stop Rafiki's DB?"
+then
+    if [ "$CLUSTER_MODE" = "SINGLE" ]; then
+        bash scripts/kubernetes/stop_db.sh || exit 1
+    else
+        bash scripts/kubernetes/stop_stolon.sh || exit 1
+    fi
+else
+    echo "Not stopping Rafiki's DB!"
+fi

--- a/scripts/kubernetes/stop_db.sh
+++ b/scripts/kubernetes/stop_db.sh
@@ -17,6 +17,22 @@
 # under the License.
 #
 
-from .container_manager import ContainerManager, InvalidServiceRequestError, ContainerService
-from .docker_swarm import DockerSwarmContainerManager
-from .kubernetes_operation import KubernetesContainerManager
+LOG_FILEPATH=$PWD/logs/stop.log
+
+source ./scripts/kubernetes/utils.sh
+
+title "Dumping database..." 
+bash ./scripts/kubernetes/save_db.sh
+
+# If database dump previously failed, prompt whether to continue script
+if [ $? -ne 0 ]
+then
+    if ! prompt "Failed to dump database. Continue?"
+    then
+        exit 1
+    fi
+fi
+
+title "Stopping Rafiki's DB..."
+kubectl delete deployment $POSTGRES_HOST
+kubectl delete service $POSTGRES_HOST

--- a/scripts/kubernetes/stop_stolon.sh
+++ b/scripts/kubernetes/stop_stolon.sh
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+source ./scripts/kubernetes/utils.sh
+
+DB_CLUSTER_RUNNING_FILE=$HOST_WORKDIR_PATH/$RUN_DIR_PATH/DB-CLUSTER-RUNNING
+
+title "Stopping Rafiki's Stolon Proxy Service..."
+kubectl delete service stolon-proxy-service
+sleep 5
+
+title "Stopping Rafiki's Stolon Proxy..."
+kubectl delete deployment stolon-proxy
+sleep 5
+
+title "Stopping Rafiki's Stolon Keeper..."
+kubectl delete statefulset stolon-keeper
+sleep 5
+
+title "Stopping Rafiki's Stolon Sentinel..."
+kubectl delete deployment stolon-sentinel
+sleep 5
+
+kubectl delete secret stolon
+
+echo "Delete PVC..."
+kubectl delete pvc database-stolon-keeper-0
+kubectl delete pvc database-stolon-keeper-1
+echo "Delete PV..."
+kubectl delete pv database-pv-0
+kubectl delete pv database-pv-1
+
+echo "Remove databse running file $DB_CLUSTER_RUNNING_FILE"
+rm -f $DB_CLUSTER_RUNNING_FILE

--- a/scripts/kubernetes/utils.sh
+++ b/scripts/kubernetes/utils.sh
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Echo title with border
+title() 
+{
+    title="| $1 |"
+    edge=$(echo "$title" | sed 's/./-/g')
+    echo "$edge"
+    echo "$title"
+    echo "$edge"
+}
+
+# Ensure kubernetes service or deployment is stable
+ensure_stable()
+{
+    log_file_path=$2
+    sleep_time=$3
+    echo "Waiting for ${sleep_time}s for $1 to stabilize..."
+    sleep $sleep_time
+    if [ $? -eq 0 ]
+    then
+        echo "$1 is running"
+    else
+        echo "Error running $1"
+        echo "Maybe $1 hasn't previously been stopped - try running scripts/stop.sh?"
+        if ! [ -z "$log_file_path" ]
+        then
+            echo "Check the logs at $log_file_path"
+        fi
+        exit 1
+    fi
+}
+
+# Check if kubernetes service and deployment is running, returns 0/1
+is_running()
+{
+    name=$1
+    if [ -z "$(kubectl get service | grep $name)" ] && [ -z "$(kubectl get deployment | grep $name)" ]
+    then
+        return 1
+    else
+        return 0
+    fi  
+}
+
+# Prompts the user with a yes/no question (defaults to yes), returns 0/1
+prompt()
+{
+    
+    text=$1
+    read -p "$text (y/n) " ok
+    if [ $ok = "n" ]
+    then
+        return 1
+    else
+        return 0
+    fi
+}
+
+
+

--- a/test/rafiki/kafka/test_kafka_cache.py
+++ b/test/rafiki/kafka/test_kafka_cache.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import pytest
+
+from rafiki.kafka import InferenceCache as KafkaInferenceCache
+from rafiki.predictor import Prediction, Query
+
+class TestKafkaCache():    
+    
+    @pytest.fixture(scope='class', autouse=True)
+    def queris(self):
+        '''
+        Initializes queris for testing
+        '''
+        return {
+            'test-query-id-1': [Query('query-1-1'), Query('query-1-2')],
+            'test-query-id-2': [Query('query-2-1'), Query('query-2-2')],
+            'test-query-id-3': [Query('query-3-1'), Query('query-3-2')]
+        }
+
+    @pytest.fixture(scope='class', autouse=True)
+    def predictions(self):
+        '''
+        Initializes queris for testing
+        '''
+        return {
+            'prediction-worker-1': [Prediction('prediction-raw-1-1', 'prediction-query-1-1', 'prediction-worker-1')],
+            'prediction-worker-2': [Prediction('prediction-raw-2-1', 'prediction-query-2-1', 'prediction-worker-2')],
+            'prediction-worker-3': [Prediction('prediction-raw-3-1', 'prediction-query-3-1', 'prediction-worker-3')]
+        }
+
+    @pytest.fixture(scope='class', autouse=True)
+    def stores(self):
+        '''
+        Initializes params stores for testing
+        '''
+        return KafkaInferenceCache()
+
+    def test_queris(self, queris, stores):
+        # Populate params
+        for query in queris.items():
+            stores.add_queries_for_worker(query[0], query[1])
+
+        for query in queris.items():
+            q = stores.pop_queries_for_worker(query[0], len(query[1]))
+            assert q == query[1]
+        
+    def test_prediction(self, predictions, stores):
+        # Populate params
+        for prediction in predictions.items():
+            stores.add_predictions_for_worker(prediction[0], prediction[1])
+
+        for prediction in predictions.items():
+            p = stores.take_prediction_for_worker(prediction[0], prediction[1][0].query_id)
+            assert p == prediction[1][0]


### PR DESCRIPTION
1. support rafiki run in kubernetes. 
  The kubernetes's scripts are store in scripts/kubernetes/ path

2. Add stolon for PostgreSQL high availability.
   Pls reference to https://github.com/sorintlab/stolon/blob/master/examples/kubernetes/README.md
   1). set CLUSTER_MODE=CLUSTER to open stolon.
   2). With stolon, you should prepare your pv in the start_stolon.sh, we use some default parameters to make nfs as pv, if your have another choice or want to change the default parameters, your should modify start_stolon.sh

3. Add kafka unit test